### PR TITLE
Evaluate if a user should see operations index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ crashlytics-build.properties
 
 
 /test/
+/bin/
+/bin/

--- a/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
@@ -35,6 +35,8 @@ public interface ConfigurationSettings {
 	static final String OPENSHIFT_ES_USER_PROFILE_PREFIX = "io.fabric8.elasticsearch.acl.user_profile_prefix";
 	static final String OPENSHIFT_WHITELISTED_USERS = "io.fabric8.elasticsearch.authentication.users";
 	
+	static final String OPENSHIFT_ROLES = "X-OpenShift-Roles";
+	
 	static final String DEFAULT_AUTH_PROXY_HEADER = "X-Proxy-Remote-User";
 	static final String DEFAULT_SECURITY_CONFIG_INDEX = "searchguard";
 	static final String DEFAULT_USER_PROFILE_PREFIX = ".kibana";

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardACL.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardACL.java
@@ -143,10 +143,13 @@ public class SearchGuardACL implements Iterable<SearchGuardACL.Acl>{
 	public void syncFrom(UserProjectCache cache, final String userProfilePrefix){
 		removeSyncAcls();
 		for (Map.Entry<String, Set<String>> userProjects : cache.getUserProjects().entrySet()) {
-			acls.add(new AclBuilder()
-					.user(userProjects.getKey())
-					.projects(formatIndicies(userProjects.getKey(), userProjects.getValue(), userProfilePrefix))
-					.build());
+			AclBuilder builder = new AclBuilder()
+				.user(userProjects.getKey())
+				.projects(formatIndicies(userProjects.getKey(), userProjects.getValue(), userProfilePrefix));
+			if(cache.isClusterAdmin(userProjects.getKey())){
+				builder.project(".operations.*");
+			}
+			acls.add(builder.build());
 		}
 	}
 	private List<String> formatIndicies(String user, Set<String> projects, final String userProfilePrefix){

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserProjectCache.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserProjectCache.java
@@ -29,7 +29,7 @@ public interface UserProjectCache {
 	 * @param project  the project
 	 * @param binding  the binding to get user info
 	 */
-	void update(final String user, Set<String> projects);
+	void update(final String user, Set<String> projects, boolean clusterAdmin);
 	
 	/**
 	 * Retrieve an unmodifiable mapping of users to their projects
@@ -43,6 +43,8 @@ public interface UserProjectCache {
 	 * @return true if the cache has an entry for a user
 	 */
 	boolean hasUser(String user);
+	
+	boolean isClusterAdmin(String user);
 	
 	void expire();
 }

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserProjectCacheMapAdapter.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserProjectCacheMapAdapter.java
@@ -38,6 +38,7 @@ public class UserProjectCacheMapAdapter implements UserProjectCache {
 	private final ESLogger logger;
 	private final Map<String, Set<String>> cache = new ConcurrentHashMap<>();
 	private final Map<String, Long> createTimes = new ConcurrentHashMap<>();
+	private final Map<String, Boolean> clusterAdmins = new ConcurrentHashMap<>();
 	private static final long EXPIRE = 1000 * 60; //1 MIN 
 
 	@Inject
@@ -55,12 +56,18 @@ public class UserProjectCacheMapAdapter implements UserProjectCache {
 	public boolean hasUser(String user) {
 		return cache.containsKey(user);
 	}
-
+	
 
 	@Override
-	public void update(final String user, final Set<String> projects) {
+	public boolean isClusterAdmin(String user) {
+		return clusterAdmins.containsKey(user) && clusterAdmins.get(user);
+	}
+
+	@Override
+	public void update(final String user, final Set<String> projects, boolean clusterAdmin) {
 		cache.put(user, new HashSet<>(projects));
 		createTimes.put(user, System.currentTimeMillis() + EXPIRE);
+		clusterAdmins.put(user, clusterAdmin);
 	}
 	
 	@Override
@@ -71,6 +78,7 @@ public class UserProjectCacheMapAdapter implements UserProjectCache {
 				logger.debug("Expiring cache entry for {}", entry.getKey());
 				cache.remove(entry.getKey());
 				createTimes.remove(entry.getKey());
+				clusterAdmins.remove(entry.getKey());
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the evaluation of a users ability to see the operations logs based on their role of cluster-admin.

@sosiouxme @ewolinetz @jimmidyson  please review.

Note: once the fabric8 client supports SAR, the isClusterAdmin can be rewritten.