### PR TITLE
add support for a curator user for ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is an OpenShift plugin to ElasticSearch to:
 
 * Dynamically update the SearchGuard ACL based on a user's name
 * Correctly return Unauthorized or Forbidden response codes
-* Transform kibana index requests to support multitent deployments
+* Transform kibana index requests to support multitenant deployments
 * Support proxy auth with fallback to client certificate auth
 
 ## Development

--- a/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
@@ -40,7 +40,7 @@ public interface ConfigurationSettings {
 	static final String DEFAULT_AUTH_PROXY_HEADER = "X-Proxy-Remote-User";
 	static final String DEFAULT_SECURITY_CONFIG_INDEX = "searchguard";
 	static final String DEFAULT_USER_PROFILE_PREFIX = ".kibana";
-	static final String [] DEFAULT_WHITELISTED_USERS = new String []{"$logging.$infra.$fluentd","$logging.$infra.$kibana"};
+	static final String [] DEFAULT_WHITELISTED_USERS = new String []{"$logging.$infra.$fluentd","$logging.$infra.$kibana","$logging.$infra.$curator"};
 	static final String DEFAULT_KIBANA_VERSION = "4.1.1";
 
 	static final int DEFAULT_ES_ACL_DELAY = 2500;

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardACL.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardACL.java
@@ -41,8 +41,10 @@ public class SearchGuardACL implements Iterable<SearchGuardACL.Acl>{
 	public static final String OPENSHIFT_SYNC = "[openshift-elasticsearch-plugin]";
 	public static final String FLUENTD_USER = "system.logging.fluentd";
 	public static final String KIBANA_USER = "system.logging.kibana";
+	public static final String CURATOR_USER = "system.logging.curator";
 	public static final String FLUENTD_EXECUTE_FILTER = "actionrequestfilter.fluentd";
 	public static final String KIBANA_EXECUTE_FILTER = "actionrequestfilter.kibana";
+	public static final String CURATOR_EXECUTE_FILTER = "actionrequestfilter.curator";
 	public static final String KIBANA_INDEX = ".kibana.*";
 	
 	@JsonProperty(value="acl")
@@ -181,6 +183,10 @@ public class SearchGuardACL implements Iterable<SearchGuardACL.Acl>{
 		// Create ACL so that kibana can only read every other index
 		Acl kibanaOthersAcl = new AclBuilder().user(KIBANA_USER).executes(KIBANA_EXECUTE_FILTER).comment("Kibana can only read from every other index").build(); 
 		acls.add(kibanaOthersAcl);
+
+		// Create ACL so that curator can find out what indices are available, and delete them
+		Acl curatorAcl = new AclBuilder().user(CURATOR_USER).executes(CURATOR_EXECUTE_FILTER).comment("Curator can list all indices and delete them").build();
+		acls.add(curatorAcl);
 	}
 	
 	private List<String> formatIndicies(String user, Set<String> projects, final String userProfilePrefix){


### PR DESCRIPTION
Curator is the Elasticsearch tool that deletes/archives old indices.  It needs very specific access, so we need to create a new user and give that user very specific access.