### PR TITLE
Updating logic to be based on settings rather than being hardcoded fo…

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
@@ -44,5 +44,16 @@ public interface ConfigurationSettings {
 	static final String DEFAULT_KIBANA_VERSION = "4.1.1";
 
 	static final int DEFAULT_ES_ACL_DELAY = 2500;
+	
+	/**
+	 * The configurations for the initial ACL as well
+	 * as what the .operations index consists of
+	 */
 
+	static final String OPENSHIFT_CONFIG_ACL_BASE = "openshift.acl.users.";
+	static final String OPENSHIFT_CONFIG_ACL_NAMES = OPENSHIFT_CONFIG_ACL_BASE + "names";
+	
+	// Below to be used at a later time?
+	static final String OPENSHIFT_CONFIG_OPS_PROJECTS = "openshift.operations.project.names";
+	static final String [] DEFAULT_OPENSHIFT_OPS_PROJECTS = new String []{"default", "openshift", "openshift-infra"};
 }

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/DynamicACLFilter.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/DynamicACLFilter.java
@@ -84,6 +84,7 @@ public class DynamicACLFilter
 	private final String userProfilePrefix;
 	private final ReentrantLock lock = new ReentrantLock();
 	private final Condition syncing = lock.newCondition();
+	private final Settings settings;
 	
 	private Boolean seeded;
 
@@ -100,6 +101,8 @@ public class DynamicACLFilter
 		this.kibanaVersion = settings.get(KIBANA_CONFIG_VERSION, DEFAULT_KIBANA_VERSION);
 		notifierService.addActionRequestListener(this);
 		logger.debug("searchGuardIndex: {}", this.searchGuardIndex);
+		
+		this.settings = settings;
 		
 		this.seeded = false;
 	}
@@ -310,7 +313,7 @@ public class DynamicACLFilter
 		}
 		
 		try {
-			acl.createInitialACLs();
+			acl.createInitialACLs(settings);
 			if ( logger.isDebugEnabled() )
 				logger.debug("Created initial ACL of '{}'", mapper.writer(new DefaultPrettyPrinter()).writeValueAsString(acl));
 			

--- a/src/test/java/io/fabric8/elasticsearch/plugin/Samples.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/Samples.java
@@ -23,7 +23,9 @@ import org.apache.commons.io.IOUtils;
 public enum Samples {
 	
 	ACL("searchguard_acl.json"),
-	OPENSHIFT_ACL("searchguard_acl_with_openshift_projects.json");
+	OPENSHIFT_ACL("searchguard_acl_with_openshift_projects.json"),
+	CONFIG_ACL("elasticsearch_test_config.yaml"),
+	CONFIG_EXPECTED_ACL("elasticsearch_test_expected.json");
 
 	private String path;
 	

--- a/src/test/resources/io/fabric8/elasticsearch/plugin/elasticsearch_test_config.yaml
+++ b/src/test/resources/io/fabric8/elasticsearch/plugin/elasticsearch_test_config.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+openshift:
+  acl:
+    users:
+      names: ["system.test.user", "system.logging.test"]
+      system.test.user:
+        execute: ["actionrequestfilter.test"]
+        actionrequestfilter.test.comment: "user can only write"
+      system.logging.test:
+        bypass: ["*"]
+        execute: ["actionrequestfilter.logging"]
+        actionrequestfilter.logging.comment: "logging can only read from every other index"
+      system.logging.test.*.comment: "test can do anything in the test index"
+      system.logging.test.*.indices: [".test.*"]
+      

--- a/src/test/resources/io/fabric8/elasticsearch/plugin/elasticsearch_test_expected.json
+++ b/src/test/resources/io/fabric8/elasticsearch/plugin/elasticsearch_test_expected.json
@@ -1,0 +1,36 @@
+{
+    "acl": [
+       {
+       	  "__Comment__": "Default is to deny all",
+       	  "filters_bypass": [],
+       	  "filters_execute": []
+       },
+       {
+           "__Comment__": "user can only write",
+           "users": [
+           "system.test.user"
+           ],
+           "filters_bypass": [],
+           "filters_execute": ["actionrequestfilter.test"]
+       },
+       {
+           "__Comment__": "logging can only read from every other index",
+           "users": [
+           "system.logging.test"
+           ],
+           "filters_bypass": [],
+           "filters_execute": ["actionrequestfilter.logging"]
+       },
+       {
+           "__Comment__": "test can do anything in the test index",
+           "users": [
+           "system.logging.test"
+           ],
+           "indices": [
+               ".test.*"
+           ],
+           "filters_bypass": ["*"],
+           "filters_execute": []
+       }
+   ]
+}


### PR DESCRIPTION
…r quicker future integration with external services

To keep previous configurations, add the following to elasticsearch.yml:
```
openshift:
  acl:
    users:
      names: ["system.logging.fluentd", "system.logging.kibana", "system.logging.curator"]
      system.logging.fluentd:
        execute: ["actionrequestfilter.fluentd"]
        actionrequestfilter.fluentd.comment: "Fluentd can only write"
      system.logging.kibana:
        bypass: ["*"]
        execute: ["actionrequestfilter.kibana"]
        actionrequestfilter.kibana.comment: "Kibana can only read from every other index"
      system.logging.kibana.*.comment: "Kibana can do anything in the kibana index"
      system.logging.kibana.*.indices: [".kibana.*"]
      system.logging.curator:
        execute: ["actionrequestfilter.curator"]
        actionrequestfilter.curator.comment: "Curator can list all indices and delete them"

```

@jcantrill @jimmidyson PTAL