### PR TITLE
removing all alias if user is not cluster-admin

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -103,6 +103,12 @@ public class KibanaSeed {
 			sortedProjects.removeAll(common);
 			indexPatterns.removeAll(common);
 			
+			// if we aren't a cluster-admin, make sure we're deleting the ADMIN_ALIAS_NAME
+			if ( !isAdmin ) {
+				logger.debug("user is not a cluster admin, ensure they don't keep/have the admin alias pattern");
+				indexPatterns.add(ADMIN_ALIAS_NAME);
+			}
+			
 			// for any to create (remaining in projects) call createIndices, createSearchmapping?, create dashboard
 			create(user, sortedProjects, false, esClient, kibanaIndex, kibanaVersion);
 			


### PR DESCRIPTION
@jcantrill ptal

`indexPatterns` list gets passed along to delete patterns from the contents