### PR TITLE
Checking for null source when checking default kibana index pattern

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -183,7 +183,8 @@ public class KibanaSeed {
 			
 			Map<String, Object> source = response.getSource();
 			
-			if ( source.containsKey(DEFAULT_INDEX_FIELD) ) {
+			// if source == null then its a different version of kibana that was used -- we'll need to recreate
+			if ( source != null && source.containsKey(DEFAULT_INDEX_FIELD) ) {
 				logger.debug("Received response with 'defaultIndex' = {}", source.get(DEFAULT_INDEX_FIELD));
 				String index = (String) source.get(DEFAULT_INDEX_FIELD);
 				


### PR DESCRIPTION
Resolves NPE as observed when resolving BZ 1377187 :
```
[2016-09-20 21:24:09,017][ERROR][io.fabric8.elasticsearch.plugin.acl.DynamicACLFilter] [Demogoblin] Error retrieving project list for 'xiazhao@redhat.com'
java.lang.NullPointerException
	at io.fabric8.elasticsearch.plugin.kibana.KibanaSeed.getDefaultIndex(KibanaSeed.java:186)
	at io.fabric8.elasticsearch.plugin.kibana.KibanaSeed.setDashboards(KibanaSeed.java:121)
	at io.fabric8.elasticsearch.plugin.acl.DynamicACLFilter.updateCache(DynamicACLFilter.java:189)
	at io.fabric8.elasticsearch.plugin.acl.DynamicACLFilter.process(DynamicACLFilter.java:153)
	at org.elasticsearch.rest.RestController$ControllerFilterChain.continueProcessing(RestController.java:283)
	at org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:180)
	at org.elasticsearch.http.HttpServer.internalDispatchRequest(HttpServer.java:121)
	at org.elasticsearch.http.HttpServer$Dispatcher.dispatchRequest(HttpServer.java:83)
	at org.elasticsearch.http.netty.NettyHttpServerTransport.dispatchRequest(NettyHttpServerTransport.java:329)
at org.elasticsearch.http.netty.HttpRequestHandler.messageReceived(HttpRequestHandler.java:65)
```

Same changes as in master :
https://github.com/fabric8io/openshift-elasticsearch-plugin/blob/master/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java#L263-L264

@jcantrill PTAL