### PR TITLE
Access allows users to see indices in other projects #46

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardRoles.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardRoles.java
@@ -177,10 +177,7 @@ public class SearchGuardRoles
 			String indexName = String.format("%s?%s", userProfilePrefix.replace('.', '?'), usernameHash);
 			
 			RoleBuilder role = new RoleBuilder(projectName)
-					.setActions(indexName, DEFAULT_ROLE_TYPE, KIBANA_INDEX_ACTIONS)
-					.setActions(DEFAULT_ROLE_INDEX, DEFAULT_ROLE_TYPE, DEFAULT_ROLE_ACTIONS)
-					.setClusters(DEFAULT_CLUSTER_ACTIONS);
-			
+					.setActions(indexName, DEFAULT_ROLE_TYPE, KIBANA_INDEX_ACTIONS);
 			builder.addRole(role.build());
 		}
 		


### PR DESCRIPTION
https://github.com/fabric8io/openshift-elasticsearch-plugin/issues/46
Remove these rules which were granting too much access:
```
"gen_kibana_45c571a156ddcef41351a713bcddee5ba7e95460":{
	"cluster":[
-		"cluster:monitor/nodes/info",
-		"cluster:monitor/health"
	],
	"indices":{
-		"*":{
-			"*":[
-				"indices:admin/validate/query*",
-				"indices:admin/get*",
-				"indices:admin/mappings/fields/get*",
-				"indices:data/read*"
-			]
-		},
		"?kibana?45c571a156ddcef41351a713bcddee5ba7e95460":{
			"*":[
				"indices:*"
			]
		}
	}
}
```