### PR TITLE
bug 1456413. Fix security error message for patterns with no indexes

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchPlugin.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchPlugin.java
@@ -33,6 +33,7 @@ import com.floragunn.searchguard.SearchGuardPlugin;
 import com.floragunn.searchguard.ssl.SearchGuardSSLPlugin;
 import com.google.common.collect.Lists;
 
+import io.fabric8.elasticsearch.plugin.filter.FieldStatsResponseFilter;
 import io.fabric8.elasticsearch.rest.KibanaUserRestHandler;
 
 public class OpenShiftElasticSearchPlugin extends Plugin implements ConfigurationSettings {
@@ -62,6 +63,7 @@ public class OpenShiftElasticSearchPlugin extends Plugin implements Configuratio
     }
 
     public void onModule(ActionModule actionModule) {
+        actionModule.registerFilter(FieldStatsResponseFilter.class);
         actionModule.registerFilter(KibanaUserReindexAction.class);
         searchguard.onModule(actionModule);
     }

--- a/src/main/java/io/fabric8/elasticsearch/plugin/PluginClient.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/PluginClient.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin;
+
+import java.util.Map;
+
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequestBuilder;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import com.floragunn.searchguard.support.ConfigConstants;
+
+/**
+ * Facade to the ES client to simplify calls
+ *
+ */
+public class PluginClient {
+
+    private static ESLogger LOGGER = Loggers.getLogger(PluginClient.class);
+    private final Client client;
+
+    @Inject
+    public PluginClient(Client client) {
+        this.client = client;
+    }
+
+    public boolean indexExists(final String index) {
+        LOGGER.trace("Checking for existance of index '{}'", index);
+        IndicesExistsRequestBuilder builder = client.admin().indices().prepareExists(index);
+        addCommonHeaders(builder);
+        IndicesExistsResponse response = builder.get();
+        boolean exists = response.isExists();
+        LOGGER.trace("Index '{}' exists? {}", index, exists);
+        return exists;
+    }
+
+    /**
+     * Create an alias for a pattern
+     * 
+     * @param aliases
+     *            a map of patterns to alias
+     * @return true if the request was acknowledged
+     */
+    public boolean alias(Map<String, String> aliases) {
+        boolean acknowledged = false;
+        if (aliases.isEmpty()) {
+            return acknowledged;
+        }
+        IndicesAliasesRequestBuilder builder = this.client.admin().indices().prepareAliases();
+        addCommonHeaders(builder);
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            LOGGER.debug("Creating alias for {} as {}", entry.getKey(), entry.getValue());
+            builder.addAlias(entry.getKey(), entry.getValue());
+        }
+        IndicesAliasesResponse response = builder.get();
+        acknowledged = response.isAcknowledged();
+        LOGGER.debug("Aliases request acknowledged? {}", acknowledged);
+        return acknowledged;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void addCommonHeaders(ActionRequestBuilder builder) {
+        builder.putHeader(ConfigConstants.SG_CONF_REQUEST_HEADER, "true");
+    }
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/filter/FieldStatsResponseFilter.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/filter/FieldStatsResponseFilter.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.filter;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.fieldstats.FieldStatsRequest;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+
+import io.fabric8.elasticsearch.plugin.PluginClient;
+
+/**
+ * Filter to modify the response code when an
+ * index does not exist.  
+ * 
+ * This is for the case
+ * where we have created an alias but it matches
+ * no indexes and the request of '_field_stats?level=indices'
+ * causes SG to generate a 403.
+ *
+ */
+public class FieldStatsResponseFilter implements ActionFilter {
+    
+    public static final String INDICES_FIELD_STATS_READ_ACTION = "indices:data/read/field_stats";
+    private static final ESLogger LOGGER = Loggers.getLogger(FieldStatsResponseFilter.class);
+    private final PluginClient client;
+    
+    @Inject
+    public FieldStatsResponseFilter(PluginClient client) {
+        this.client = client;
+    }
+    
+    @Override
+    public int order() {
+        return Integer.MIN_VALUE;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    @Override
+    public  void apply(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
+        chain.proceed(action, response, listener);
+    }
+    
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void apply(final Task task, final String action, final ActionRequest request, final ActionListener listener,
+            final ActionFilterChain chain) {
+        chain.proceed(task, action, request, new ActionListener<ActionResponse>() {
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onResponse(ActionResponse response) {
+                listener.onResponse(response);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                LOGGER.trace("Evaluating failure for action '{}' to see if we need to change from a 403", action);
+                Throwable err = e;
+                if( INDICES_FIELD_STATS_READ_ACTION.equals(action) && request instanceof FieldStatsRequest) {
+                    for (String index : ((FieldStatsRequest)request).indices()) {
+                        if(!client.indexExists(index)) {
+                            LOGGER.trace("Modifying the response to be {}", RestStatus.NOT_FOUND);
+                            err = new ElasticsearchException("The index '" + index + "' was not found. This could mean data has not yet been collected.",
+                                    RestStatus.NOT_FOUND);
+                            break;
+                        }
+                    }
+                }
+                listener.onFailure(err);
+            }
+        });
+
+    }
+}

--- a/src/main/java/io/fabric8/elasticsearch/rest/KibanaUserRestHandler.java
+++ b/src/main/java/io/fabric8/elasticsearch/rest/KibanaUserRestHandler.java
@@ -28,13 +28,14 @@ import org.elasticsearch.rest.RestRequest;
 
 import io.fabric8.elasticsearch.plugin.ConfigurationSettings;
 import io.fabric8.elasticsearch.plugin.KibanaUserReindexFilter;
+import io.fabric8.elasticsearch.util.RequestUtils;
 
 public class KibanaUserRestHandler extends BaseRestHandler implements ConfigurationSettings {
 
     private final ESLogger logger;
 
     @Inject
-    public KibanaUserRestHandler(Settings settings, RestController controller, Client client) {
+    public KibanaUserRestHandler(Settings settings, RestController controller, Client client, RequestUtils utils) {
         super(settings, controller, client);
         this.logger = Loggers.getLogger(KibanaUserRestHandler.class);
 
@@ -43,7 +44,7 @@ public class KibanaUserRestHandler extends BaseRestHandler implements Configurat
         logger.debug("Starting with Kibana reindexing feature enabled: {}", reindexEnabled);
 
         if (reindexEnabled) {
-            controller.registerFilter(new KibanaUserReindexFilter(settings, logger));
+            controller.registerFilter(new KibanaUserReindexFilter(settings, logger, utils));
         }
     }
 

--- a/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
+++ b/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.util;
+
+import org.apache.commons.lang.ObjectUtils;
+import org.elasticsearch.common.ContextAndHeaderHolder;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+
+import io.fabric8.elasticsearch.plugin.ConfigurationSettings;
+
+public class RequestUtils implements ConfigurationSettings  {
+
+    private String proxyUserHeader;
+
+    @Inject
+    public RequestUtils(final Settings settings) {
+        this.proxyUserHeader = settings.get(SEARCHGUARD_AUTHENTICATION_PROXY_HEADER, DEFAULT_AUTH_PROXY_HEADER);
+    }
+    
+    public String getUser(ContextAndHeaderHolder request) {
+        return (String) ObjectUtils.defaultIfNull(request.getHeader(proxyUserHeader), "");
+    }
+}

--- a/src/test/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchPluginTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchPluginTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin;
+
+
+import org.elasticsearch.action.ActionModule;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import com.floragunn.searchguard.filter.SearchGuardFilter;
+
+import io.fabric8.elasticsearch.plugin.filter.FieldStatsResponseFilter;
+
+public class OpenShiftElasticSearchPluginTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void testSearchGuardFilterIsRegisteredLast() {
+        ActionModule module = Mockito.spy(new ActionModule(true));
+        Settings settings = Settings.EMPTY;
+        OpenShiftElasticSearchPlugin plugin = new OpenShiftElasticSearchPlugin(settings );
+        
+        plugin.onModule(module);
+        
+        InOrder inOrder = Mockito.inOrder(module);
+        inOrder.verify(module).registerFilter(FieldStatsResponseFilter.class);
+        inOrder.verify(module).registerFilter(KibanaUserReindexAction.class);
+        inOrder.verify(module).registerFilter(SearchGuardFilter.class);
+    }
+
+}

--- a/src/test/java/io/fabric8/elasticsearch/plugin/filter/FieldStatsResponseFilterTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/filter/FieldStatsResponseFilterTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.fieldstats.FieldStatsRequest;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.tasks.Task;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import io.fabric8.elasticsearch.plugin.PluginClient;
+
+@SuppressWarnings("rawtypes")
+public class FieldStatsResponseFilterTest {
+
+    private FieldStatsResponseFilter filter;
+    private ActionFilterChain chain = mock(ActionFilterChain.class);
+    private String action = FieldStatsResponseFilter.INDICES_FIELD_STATS_READ_ACTION;
+    private ActionResponse response = mock(ActionResponse.class);
+    private ActionRequest request = mock(ActionRequest.class);
+    private ActionListener listener = mock(ActionListener.class);
+    private Task task = mock(Task.class);
+    private RuntimeException exception = mock(RuntimeException.class);
+    private PluginClient client = mock(PluginClient.class);
+    
+    @Before
+    public void setUp() throws Exception {
+        filter = new FieldStatsResponseFilter(client);
+    }
+
+    @Test
+    public void testFilterIsOrderedToBeFirst() {
+        assertEquals(Integer.MIN_VALUE, filter.order());
+    }
+    
+    private void givenAnExeptionOccurs() {
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                ActionListener listener = (ActionListener) args[3];
+                listener.onFailure(exception);
+                return null;
+            }
+        }).when(chain).proceed(any(Task.class), anyString(), any(ActionRequest.class), any(ActionListener.class));
+    }
+    
+    private FieldStatsRequest givenAFieldStatsRequest() {
+        FieldStatsRequest request = mock(FieldStatsRequest.class);
+        when(request.indices()).thenReturn(new String [] {"project.foo.uuid.*"});
+        return request;
+    }
+
+    @Test
+    public void testApplyActionRequestMakesPassThroughCallToOnFailureWithModifiedReturnValueWhenIndexIsMissing() {
+        //given the chain will be called and wrappers the listener
+        givenAnExeptionOccurs();
+        FieldStatsRequest request = givenAFieldStatsRequest();
+        when(client.indexExists(anyString())).thenReturn(false);
+        
+        //when
+        filter.apply(task, action, request, listener, chain );
+        
+        //then the original listener should be notified with the modified exception
+        verify(listener).onFailure(any(ElasticsearchException.class));
+    }
+
+    @Test
+    public void testApplyActionRequestMakesPassThroughCallToOnFailureWithModifiedReturnValueWhenIndexExists() {
+        //given the chain will be called and wrappers the listener
+        givenAnExeptionOccurs();
+        FieldStatsRequest request = givenAFieldStatsRequest();
+        when(client.indexExists(anyString())).thenReturn(true);
+        
+        //when
+        filter.apply(task, action, request, listener, chain );
+        
+        //then the original listener should be notified with the modified exception
+        verify(listener).onFailure(any(ElasticsearchException.class));
+    }
+    
+    @Test
+    public void testApplyActionRequestMakesPassThroughCallToOnFailureWhenRequestIsNotReadFieldsRequest() {
+        //given the chain will be called and wrappers the listener
+        givenAnExeptionOccurs();
+        
+        //when
+        filter.apply(task, action, request, listener, chain );
+        
+        //then the original listener should be notified
+        verify(listener).onFailure(exception);
+    }
+    
+    @Test
+    public void testApplyActionRequestMakesPassThroughCallToOnFailureWhenActionIsNotOfInterest() {
+        //given the chain will be called and wrappers the listener
+        givenAnExeptionOccurs();
+        request = mock(FieldStatsRequest.class);
+        //when
+        filter.apply(task, "someaction", request, listener, chain );
+        
+        //then the original listener should be notified
+        verify(listener).onFailure(exception);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testApplyActionRequestMakesPassThroughCallToOnResponse() {
+        //given the chain will be called and wrappers the listener
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                ActionListener listener = (ActionListener) args[3];
+                listener.onResponse(response);
+                return null;
+            }
+        }).when(chain).proceed(any(Task.class), anyString(), any(ActionRequest.class), any(ActionListener.class));
+        
+        //when
+        filter.apply(task, action, request, listener, chain );
+        
+        //then the original listener should be notified
+        verify(listener).onResponse(response);
+    }
+    
+    @Test
+    public void testApplyActionResponsePassesDownTheChain() {
+        filter.apply(action, response, listener, chain );
+        verify(chain, times(1)).proceed(action, response, listener);
+    }
+
+}

--- a/src/test/java/io/fabric8/elasticsearch/util/RequestUtilsTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/util/RequestUtilsTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.fabric8.elasticsearch.plugin.ConfigurationSettings;
+
+public class RequestUtilsTest {
+    
+    private static final String PROXY_HEADER = "aValue";
+    private static final String USER = "auser";
+    private RequestUtils util;
+    
+    @Before
+    public void setUp() throws Exception {
+        Settings settings = Settings.builder().put(ConfigurationSettings.SEARCHGUARD_AUTHENTICATION_PROXY_HEADER, PROXY_HEADER).build();
+        util = new RequestUtils(settings);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testGetUserFromHeader() {
+        ActionRequest request = new MockActionRequest();
+        
+        assertEquals(USER, util.getUser(request));
+    }
+    
+    private class MockActionRequest extends ActionRequest<MockActionRequest> {
+        MockActionRequest(){
+            headers = new HashMap<>();
+            headers.put(PROXY_HEADER,USER);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
This PR fixes the error message displayed to users in kibana:

* Creates mappings only for indices that exist
* Modifies the response when fieldstat call is made

![image](https://cloud.githubusercontent.com/assets/4548408/26734536/692d633a-478c-11e7-92dd-8717df96ebfe.png)
