### PR TITLE
project.* index pattern causes exception

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -472,7 +472,9 @@ public class KibanaSeed implements ConfigurationSettings {
                 if (index.startsWith(projectPrefixTest)) {
                     start = projectPrefixTest.length();
                 }
-                return index.substring(start, wildcard);
+                if (wildcard > start) {
+                    return index.substring(start, wildcard);
+                }
             }
         }
 


### PR DESCRIPTION
If the user specifies an index pattern in Kibana like "project.*"
because they want to have a search for all projects that they
have access to, this will cause an exception in the openshift
elasticsearch plugin string handling.
The fix is to perform better string bounds checking.