### PR TITLE
modify roles to be user based so all of a users indexes are visible in a single query

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/ConfigurationSettings.java
@@ -87,6 +87,13 @@ public interface ConfigurationSettings extends KibanaIndexMode{
      * Kibana index.
      */
     static final String OPENSHIFT_DYNAMIC_ENABLED_FLAG = "openshift.acl.dynamic.enabled";
+    
+    /**
+     * The strategy to use for generating roles and role mappings
+     */
+    static final String OPENSHIFT_ACL_ROLE_STRATEGY = "openshift.acl.role_strategy";
+    static final String DEFAULT_ACL_ROLE_STRATEGY = "user";
+    
     static final String OPENSHIFT_KIBANA_REWRITE_ENABLED_FLAG = "openshift.kibana.rewrite.enabled";
 
     

--- a/src/main/java/io/fabric8/elasticsearch/plugin/KibanaIndexMode.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/KibanaIndexMode.java
@@ -28,4 +28,5 @@ public interface KibanaIndexMode {
     
     static final String UNIQUE = "unique";
     static final String SHARED_OPS = "shared_ops";
+    static final String DEFAULT_MODE = UNIQUE;
 }

--- a/src/main/java/io/fabric8/elasticsearch/plugin/PluginSettings.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/PluginSettings.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin;
+
+import static io.fabric8.elasticsearch.plugin.acl.SearchGuardSyncStrategyFactory.PROJECT;
+import static io.fabric8.elasticsearch.plugin.acl.SearchGuardSyncStrategyFactory.USER;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+public class PluginSettings implements ConfigurationSettings {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(PluginSettings.class);
+    
+    private String kibanaIndexMode;
+    private String roleStrategy;
+    private final String cdmProjectPrefix;
+    private final String defaultKibanaIndex;
+    private final String searchGuardIndex;
+    private final String kibanaVersion;
+    private final String kbnVersionHeader;
+    private final Boolean enabled;
+    
+    @Inject
+    public PluginSettings(final Settings settings) {
+        this.kibanaIndexMode = settings.get(OPENSHIFT_KIBANA_INDEX_MODE, KibanaIndexMode.DEFAULT_MODE);
+        if(!ArrayUtils.contains(new String [] {UNIQUE, SHARED_OPS}, kibanaIndexMode.toLowerCase())) {
+            this.kibanaIndexMode = UNIQUE;
+        }
+        
+        this.roleStrategy = settings.get(OPENSHIFT_ACL_ROLE_STRATEGY, DEFAULT_ACL_ROLE_STRATEGY);
+        if(!ArrayUtils.contains(new String [] {PROJECT, USER}, roleStrategy.toLowerCase())) {
+            this.kibanaIndexMode = USER;
+        }
+
+        this.cdmProjectPrefix = settings.get(OPENSHIFT_CONFIG_PROJECT_INDEX_PREFIX,
+                OPENSHIFT_DEFAULT_PROJECT_INDEX_PREFIX);
+        this.defaultKibanaIndex = settings.get(KIBANA_CONFIG_INDEX_NAME, DEFAULT_USER_PROFILE_PREFIX);
+        this.searchGuardIndex = settings.get(SEARCHGUARD_CONFIG_INDEX_NAME, DEFAULT_SECURITY_CONFIG_INDEX);
+        this.kibanaVersion = settings.get(KIBANA_CONFIG_VERSION, DEFAULT_KIBANA_VERSION);
+        this.kbnVersionHeader = settings.get(KIBANA_VERSION_HEADER, DEFAULT_KIBANA_VERSION_HEADER);
+        this.enabled = settings.getAsBoolean(OPENSHIFT_DYNAMIC_ENABLED_FLAG, OPENSHIFT_DYNAMIC_ENABLED_DEFAULT);
+
+        LOGGER.info("Using kibanaIndexMode: '{}'", this.kibanaIndexMode);
+        LOGGER.debug("searchGuardIndex: {}", this.searchGuardIndex);
+        LOGGER.debug("roleStrategy: {}", this.roleStrategy);
+
+    }
+    
+    public String getRoleStrategy() {
+        return this.roleStrategy;
+    }
+    
+    public String getKibanaIndexMode() {
+        return kibanaIndexMode;
+    }
+    
+    public String getCdmProjectPrefix() {
+        return cdmProjectPrefix;
+    }
+    
+    public String getDefaultKibanaIndex() {
+        return defaultKibanaIndex;
+    }
+    
+    public String getSearchGuardIndex() {
+        return searchGuardIndex;
+    }
+
+    public String getKibanaVersion() {
+        return kibanaVersion;
+    }
+
+    public String getKbnVersionHeader() {
+        return kbnVersionHeader;
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setKibanaIndexMode(String kibanaIndexMode) {
+        this.kibanaIndexMode = kibanaIndexMode;
+    }
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/BaseRolesMappingSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/BaseRolesMappingSyncStrategy.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import static io.fabric8.elasticsearch.plugin.acl.SearchGuardRoles.ROLE_PREFIX;
+
+import java.util.Iterator;
+
+import io.fabric8.elasticsearch.plugin.acl.SearchGuardRolesMapping.RolesMapping;
+
+public abstract class BaseRolesMappingSyncStrategy implements RolesMappingSyncStrategy {
+
+    protected final SearchGuardRolesMapping mappings;
+    
+    protected BaseRolesMappingSyncStrategy(final SearchGuardRolesMapping mappings) {
+        this.mappings = mappings;
+    }
+
+
+    // Remove roles that start with "gen_"
+    private void removeSyncAcls() {
+        for (Iterator<RolesMapping> i = mappings.iterator(); i.hasNext();) {
+            RolesMapping mapping = i.next();
+            if (mapping.getName() != null && mapping.getName().startsWith(ROLE_PREFIX)) {
+                mappings.removeRolesMapping(mapping);
+            }
+        }
+    }
+
+
+    protected abstract void syncFromImpl(UserProjectCache cache, RolesMappingBuilder builder);
+    
+    @Override
+    public void syncFrom(UserProjectCache cache) {
+        removeSyncAcls();
+        RolesMappingBuilder builder = new RolesMappingBuilder();
+        syncFromImpl(cache, builder);
+        mappings.addAll(builder.build());
+    }
+
+    
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/BaseRolesSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/BaseRolesSyncStrategy.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import static io.fabric8.elasticsearch.plugin.acl.SearchGuardRoles.USER_PREFIX;
+
+import java.util.Iterator;
+
+import io.fabric8.elasticsearch.plugin.OpenshiftRequestContextFactory;
+import io.fabric8.elasticsearch.plugin.acl.SearchGuardRoles.Roles;
+
+public abstract class BaseRolesSyncStrategy implements RolesSyncStrategy {
+
+    protected SearchGuardRoles roles;
+    private final String userProfilePrefix;
+   
+    protected BaseRolesSyncStrategy(SearchGuardRoles roles, String userProfilePrefix) {
+        this.roles = roles;
+        this.userProfilePrefix = userProfilePrefix;
+
+    }
+    
+    protected abstract void syncFromImpl(UserProjectCache cache, RolesBuilder builder);
+    
+    @Override
+    public void syncFrom(UserProjectCache cache) {
+        removeSyncAcls();
+        RolesBuilder builder = new RolesBuilder();
+        syncFromImpl(cache, builder);
+        roles.addAll(builder.build());
+    }
+
+    // Remove roles that start with "gen_"
+    private void removeSyncAcls() {
+        for (Iterator<Roles> i = roles.iterator(); i.hasNext();) {
+            Roles role = i.next();
+            if (role.getName() != null && role.getName().startsWith(SearchGuardRoles.ROLE_PREFIX)) {
+                roles.removeRole(role);
+            }
+        }
+    }
+    
+    protected String formatKibanaIndexName(UserProjectCache cache, String username, String token, String kibanaIndexMode) {
+        String kibanaIndex = OpenshiftRequestContextFactory.getKibanaIndex(userProfilePrefix, 
+                kibanaIndexMode, username, cache.isOperationsUser(username, token));
+        return kibanaIndex.replace('.','?');
+    }
+    
+    
+    protected String formatKibanaRoleName(UserProjectCache cache, String username, String token) {
+        boolean isOperationsUser = cache.isOperationsUser(username, token);
+        if (isOperationsUser) {
+            return SearchGuardRolesMapping.KIBANA_SHARED_ROLE;
+        } else {
+            return SearchGuardRoles.formatUniqueKibanaRoleName(username);
+        }
+    }
+    
+    public static String formatUserRoleName(String username) {
+        return String.format("%s_%s", USER_PREFIX, username.replaceAll("[\\.@]", "_"));
+    }
+
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/ProjectRolesMappingSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/ProjectRolesMappingSyncStrategy.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import static io.fabric8.elasticsearch.plugin.acl.SearchGuardRoles.PROJECT_PREFIX;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class ProjectRolesMappingSyncStrategy extends BaseRolesMappingSyncStrategy {
+
+    public ProjectRolesMappingSyncStrategy(SearchGuardRolesMapping rolesMapping) {
+        super(rolesMapping);
+    }
+    
+    @Override
+    protected  void syncFromImpl(UserProjectCache cache, RolesMappingBuilder builder) {
+        for (Entry<SimpleImmutableEntry<String, String>, Set<String>> userProjects : cache.getUserProjects()
+                .entrySet()) {
+            String username = userProjects.getKey().getKey();
+            String token = userProjects.getKey().getValue();
+
+            for (String project : userProjects.getValue()) {
+                String projectRoleName = String.format("%s_%s", PROJECT_PREFIX, project.replace('.', '_'));
+
+                builder.addUser(projectRoleName, username);
+            }
+
+            if (cache.isOperationsUser(username, token)) {
+                builder.addUser(SearchGuardRolesMapping.ADMIN_ROLE, username);
+                builder.addUser(SearchGuardRolesMapping.KIBANA_SHARED_ROLE, username);
+            } else {
+                //role mapping for user's kibana index
+                String kibanaRoleName = SearchGuardRoles.formatUniqueKibanaRoleName(username);
+                builder.addUser(kibanaRoleName, username);
+            }
+        }
+    }
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/ProjectRolesSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/ProjectRolesSyncStrategy.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * SearchGuard Roles Document sync strategy based on roles 
+ * derived from projects.  This should generate role mappings like:
+ * 
+ * gen_kibana_a1881c06eec96db9901c7bbfe41c42a3f08e9cb4:
+ *   users: [user2]
+ * gen_ocp_kibana_shared:
+ *   users: [user1, user3]
+ *  gen_project_foo_bar:
+ *   users: [user2]
+ * gen_project_operations:
+ *   users: [user1, user3]
+ * 
+ */
+public class ProjectRolesSyncStrategy extends BaseRolesSyncStrategy {
+
+
+    private final String cdmProjectPrefix;
+    private final String kibanaIndexMode;
+    
+    public ProjectRolesSyncStrategy(SearchGuardRoles roles, final String userProfilePrefix, final String cdmProjectPrefix, final String kibanaIndexMode) {
+        super(roles, userProfilePrefix);
+        this.roles = roles;
+        this.cdmProjectPrefix = cdmProjectPrefix;
+        this.kibanaIndexMode = kibanaIndexMode;
+    }
+
+    @Override
+    public void syncFromImpl(UserProjectCache cache, RolesBuilder builder) {
+        for (String project : cache.getAllProjects()) {
+            String projectName = String.format("%s_%s", SearchGuardRoles.PROJECT_PREFIX, project.replace('.', '_'));
+            String indexName = String.format("%s?*", project.replace('.', '?'));
+            RoleBuilder role = new RoleBuilder(projectName).setActions(indexName, ALL,
+                    PROJECT_ROLE_ACTIONS);
+
+            // If using common data model, allow access to both the
+            // $projname.$uuid.* indices and
+            // the project.$projname.$uuid.* indices for backwards compatibility
+            if (StringUtils.isNotEmpty(cdmProjectPrefix)) {
+                indexName = String.format("%s?%s?*", cdmProjectPrefix.replace('.', '?'), project.replace('.', '?'));
+                role.setActions(indexName, ALL, PROJECT_ROLE_ACTIONS);
+            }
+
+            builder.addRole(role.build());
+        }
+        
+        boolean foundAnOpsUser = false;
+        //create roles for every user we know about to their kibana index
+        for (Map.Entry<SimpleImmutableEntry<String, String>, Set<String>> userToProjects : cache.getUserProjects()
+                .entrySet()) {
+            String username = userToProjects.getKey().getKey();
+            String token = userToProjects.getKey().getValue();
+            
+            String roleName = formatKibanaRoleName(cache, username, token);
+            String indexName = formatKibanaIndexName(cache, username, token, kibanaIndexMode);
+
+            RoleBuilder role = new RoleBuilder(roleName)
+                    .setActions(indexName, ALL, KIBANA_ROLE_INDEX_ACTIONS);
+            if (cache.isOperationsUser(username, token)) {
+                foundAnOpsUser = true;
+                role.setClusters(KIBANA_ROLE_CLUSTER_ACTIONS)
+                    .setActions(ALL, ALL, KIBANA_ROLE_ALL_INDEX_ACTIONS);
+            }
+            builder.addRole(role.build());
+        }
+        if (foundAnOpsUser) {
+            RoleBuilder opsRole = new RoleBuilder(SearchGuardRolesMapping.ADMIN_ROLE)
+                    .setClusters(OPERATIONS_ROLE_CLUSTER_ACTIONS)
+                    .setActions("?operations?", ALL, OPERATIONS_ROLE_OPERATIONS_ACTIONS)
+                    .setActions("*?*?*", ALL, OPERATIONS_ROLE_ANY_ACTIONS);
+            builder.addRole(opsRole.build());
+        }
+    }
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/RolesMappingSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/RolesMappingSyncStrategy.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+/**
+ * Strategy to sync between SearchGuard Documents and memory cache  
+ *
+ */
+public interface RolesMappingSyncStrategy {
+
+    /**
+     * Sync the given cache to 
+     * @param cache   The cache from which to sync
+     */
+    void syncFrom(final UserProjectCache cache);
+    
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/RolesSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/RolesSyncStrategy.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+/**
+ * Strategy to sync between SearchGuard Documents and memory cache  
+ *
+ */
+public interface RolesSyncStrategy {
+    
+    static final String[] PROJECT_ROLE_ACTIONS = { "INDEX_PROJECT" };
+    static final String[] KIBANA_ROLE_ALL_INDEX_ACTIONS = { "INDEX_ANY_KIBANA" };
+    static final String[] KIBANA_ROLE_INDEX_ACTIONS = { "INDEX_KIBANA" };
+    static final String[] KIBANA_ROLE_CLUSTER_ACTIONS = { "CLUSTER_MONITOR_KIBANA" };
+    static final String[] OPERATIONS_ROLE_CLUSTER_ACTIONS = { "CLUSTER_OPERATIONS" };
+    static final String[] OPERATIONS_ROLE_OPERATIONS_ACTIONS = { "INDEX_OPERATIONS" };
+    static final String[] OPERATIONS_ROLE_ANY_ACTIONS = { "INDEX_ANY_OPERATIONS" };
+    static final String ALL = "*";
+
+    /**
+     * Sync the given cache to 
+     * @param cache   The cache from which to sync
+     */
+    void syncFrom(final UserProjectCache cache);
+    
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardSyncStrategyFactory.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardSyncStrategyFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import org.elasticsearch.common.inject.Inject;
+
+import io.fabric8.elasticsearch.plugin.PluginSettings;
+
+/**
+ * Factory class for creating SearchGuard sync strategies
+ *
+ */
+public class SearchGuardSyncStrategyFactory {
+    
+    public static final String PROJECT = "project";
+    public static final String USER = "user";
+    
+    private final PluginSettings settings;
+
+    @Inject
+    public SearchGuardSyncStrategyFactory(final PluginSettings settings) {
+        this.settings = settings;
+    }
+
+    public RolesMappingSyncStrategy createRolesMappingSyncStrategy(SearchGuardRolesMapping mapping) {
+        if(PROJECT.equals(settings.getRoleStrategy())) {
+            return new ProjectRolesMappingSyncStrategy(mapping);
+        }
+        return new UserRolesMappingSyncStrategy(mapping);
+    }
+    
+    public RolesSyncStrategy createRolesSyncStrategy(SearchGuardRoles roles) {
+        if(PROJECT.equals(settings.getRoleStrategy())) {
+            return new ProjectRolesSyncStrategy(roles, settings.getDefaultKibanaIndex(), settings.getCdmProjectPrefix(), settings.getKibanaIndexMode());
+        }
+        return new UserRolesSyncStrategy(roles, settings.getDefaultKibanaIndex(), settings.getCdmProjectPrefix(), settings.getKibanaIndexMode());
+    }
+    
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserRolesMappingSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserRolesMappingSyncStrategy.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * SearchGuard Roles Document sync strategy based on roles 
+ * derived from users.  This should generate role mappings like:
+ * 
+ * gen_project_operations:
+ *   users: [user1, user3]
+ * gen_ocp_kibana_shared:
+ *   users: [user1, user3]
+ * gen_user_user2:
+ *   users: [user2]
+ */
+public class UserRolesMappingSyncStrategy extends BaseRolesMappingSyncStrategy {
+
+    public UserRolesMappingSyncStrategy(SearchGuardRolesMapping mapping) {
+        super(mapping);
+    }
+
+    @Override
+    protected void syncFromImpl(UserProjectCache cache, RolesMappingBuilder builder) {
+        Set<String> opsUsers = new HashSet<>();
+        for (Entry<SimpleImmutableEntry<String, String>, Set<String>> userProjects : cache.getUserProjects()
+                .entrySet()) {
+            String username = userProjects.getKey().getKey();
+            String token = userProjects.getKey().getValue();
+
+            if (cache.isOperationsUser(username, token)) {
+                opsUsers.add(username);
+            } else {
+                String roleName = BaseRolesSyncStrategy.formatUserRoleName(username);
+                builder.addUser(roleName, username);
+            }
+        }
+        for (String user : opsUsers) {
+            builder.addUser(SearchGuardRolesMapping.ADMIN_ROLE, user);
+            builder.addUser(SearchGuardRolesMapping.KIBANA_SHARED_ROLE, user);
+        }
+    }
+
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserRolesSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserRolesSyncStrategy.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.acl;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+public class UserRolesSyncStrategy extends BaseRolesSyncStrategy implements RolesSyncStrategy {
+
+    private final String cdmProjectPrefix;
+    private final String kibanaIndexMode;
+
+    public UserRolesSyncStrategy(SearchGuardRoles roles, String userProfilePrefix, String cdmProjectPrefix, String kibanaIndexMode) {
+        super(roles, userProfilePrefix);
+        this.cdmProjectPrefix = cdmProjectPrefix;
+        this.kibanaIndexMode = kibanaIndexMode;
+    }
+
+    protected void syncFromImpl(UserProjectCache cache, RolesBuilder builder) {
+        boolean foundAnOpsUser = false;
+        //create roles for every user we know about to their kibana index
+        for (Map.Entry<SimpleImmutableEntry<String, String>, Set<String>> userToProjects : cache.getUserProjects()
+                .entrySet()) {
+
+            String user = userToProjects.getKey().getKey();
+            String token = userToProjects.getKey().getValue();
+            if (cache.isOperationsUser(user, token)) {
+                foundAnOpsUser = true;
+            } else {
+                String roleName = formatUserRoleName(user);
+                
+                //permissions for kibana Index
+                String kibIndexName = formatKibanaIndexName(cache, user, token, kibanaIndexMode);
+                RoleBuilder role = new RoleBuilder(roleName)
+                        .setActions(kibIndexName, ALL, KIBANA_ROLE_INDEX_ACTIONS);
+                
+                //permissions for projects
+                for (String project : userToProjects.getValue()) {
+                    String indexName = String.format("%s?*", project.replace('.', '?'));
+                    role.setActions(indexName, ALL, PROJECT_ROLE_ACTIONS);
+                    // If using common data model, allow access to both the
+                    // $projname.$uuid.* indices and
+                    // the project.$projname.$uuid.* indices for backwards compatibility
+                    if (StringUtils.isNotEmpty(cdmProjectPrefix)) {
+                        indexName = String.format("%s?%s?*", cdmProjectPrefix.replace('.', '?'), project.replace('.', '?'));
+                        role.setActions(indexName, ALL, PROJECT_ROLE_ACTIONS);
+                    }
+                }
+                
+                //permissions for alias
+                role.setActions(formatAllAlias(user), ALL, PROJECT_ROLE_ACTIONS);
+                
+                builder.addRole(role.build());
+            }
+        }
+        if (foundAnOpsUser) {
+            RoleBuilder opsRole = new RoleBuilder(SearchGuardRolesMapping.ADMIN_ROLE)
+                    .setClusters(OPERATIONS_ROLE_CLUSTER_ACTIONS)
+                    .setActions("?operations?", ALL, OPERATIONS_ROLE_OPERATIONS_ACTIONS)
+                    .setActions("*?*?*", ALL, OPERATIONS_ROLE_ANY_ACTIONS);
+            builder.addRole(opsRole.build());
+            RoleBuilder kibanaOpsRole = new RoleBuilder(SearchGuardRolesMapping.KIBANA_SHARED_ROLE)
+                    .setClusters(KIBANA_ROLE_CLUSTER_ACTIONS)
+                    .setActions(ALL, ALL, KIBANA_ROLE_ALL_INDEX_ACTIONS);
+            builder.addRole(kibanaOpsRole.build());
+        }        
+    }
+
+    public static String formatAllAlias(final String user) {
+        return ".all_" + user.replaceAll("[\\.@]", "_");
+    }
+}

--- a/src/test/java/io/fabric8/elasticsearch/plugin/PluginSettingsTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/PluginSettingsTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin;
+
+import static org.junit.Assert.assertEquals;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+public class PluginSettingsTest {
+
+    private Settings settings = Settings.EMPTY;
+
+    @Test
+    public void testRoleStrategyDefault() {
+        PluginSettings plugin = new PluginSettings(settings);
+        assertEquals("Exp. the plugin default to make roles based on users", "user", plugin.getRoleStrategy());
+    }
+
+    @Test
+    public void testKibanaIndexModeDefault() {
+        PluginSettings plugin = new PluginSettings(settings);
+        assertEquals("Exp. the plugin default to make kibana index mode unique", "unique", plugin.getKibanaIndexMode());
+    }
+
+}

--- a/src/test/java/io/fabric8/elasticsearch/plugin/Samples.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/Samples.java
@@ -29,7 +29,9 @@ public enum Samples {
     OPENSHIFT_ROLESMAPPING_ACL("searchguard_rolesmapping_acl_with_openshift_projects.yml"),
     ROLES_OPS_SHARED_KIBANA_INDEX("roles_ops_shared_kibana_index.yml"),
     ROLES_OPS_SHARED_KIBANA_INDEX_WITH_UNIQUE("roles_ops_shared_kibana_index_with_unique.yml"),
-    ROLESMAPPING_OPS_SHARED_KIBANA_INDEX_WITH_UNIQUE("rolesmapping_ops_shared_kibana_index.yml");
+    ROLESMAPPING_OPS_SHARED_KIBANA_INDEX_WITH_UNIQUE("rolesmapping_ops_shared_kibana_index.yml"),
+    USER_ROLESMAPPING_STRATEGY("user_rolesmapping_shared_ops_kibana_index_with_unique.yml"),
+    USER_ROLES_STRATEGY("user_role_with_shared_kibana_index_with_unique.yml");
 
     private String path;
 

--- a/src/test/resources/io/fabric8/elasticsearch/plugin/user_role_with_shared_kibana_index_with_unique.yml
+++ b/src/test/resources/io/fabric8/elasticsearch/plugin/user_role_with_shared_kibana_index_with_unique.yml
@@ -1,0 +1,26 @@
+gen_ocp_kibana_shared:
+  cluster: [CLUSTER_MONITOR_KIBANA]
+  indices:
+    '*':
+      '*': [INDEX_ANY_KIBANA]
+gen_project_operations:
+  cluster: [CLUSTER_OPERATIONS]
+  indices:
+    '*?*?*':
+      '*': [INDEX_ANY_OPERATIONS]
+    ?operations?:
+      '*': [INDEX_OPERATIONS]
+gen_user_user2_bar_email_com:
+  indices:
+    .all_user2_bar_email_com:
+      '*': [INDEX_PROJECT]
+    ?kibana?994a33f6a157ba4a286395f81a4333db1e6cefb6:
+      '*': [INDEX_KIBANA]
+    ?project?foo?bar?*:
+      '*': [INDEX_PROJECT]
+    ?project?xyz?*:
+      '*': [INDEX_PROJECT]
+    foo?bar?*:
+      '*': [INDEX_PROJECT]
+    xyz?*:
+      '*': [INDEX_PROJECT]

--- a/src/test/resources/io/fabric8/elasticsearch/plugin/user_rolesmapping_shared_ops_kibana_index_with_unique.yml
+++ b/src/test/resources/io/fabric8/elasticsearch/plugin/user_rolesmapping_shared_ops_kibana_index_with_unique.yml
@@ -1,0 +1,6 @@
+gen_ocp_kibana_shared:
+  users: [user1, user3]
+gen_project_operations:
+  users: [user1, user3]
+gen_user_user2_bar_email_com:
+  users: [user2.bar@email.com]


### PR DESCRIPTION
This PR introduces:
* ACL documents generated based on roles per user instead of per project [1]
* Resolves issue where user is unable to query across multiple indexes

The configuration option `openshift.acl.role_strategy` allows you to switch between generating roles per project where running queries across multiple project indices is not possible and generating roles per user.  The later creates proper role permissions to query across the indices you own.  I don't see us promoting or encouraging us of project role strategy going forward; this was a refactoring convenience to confirm everything was properly tested and backwards compatible.


[1] https://github.com/jcantrill/openshift-elasticsearch-plugin/blob/60f9d06520b73bcbd8bb74bfd17b71f89ac3d6ac/src/test/resources/io/fabric8/elasticsearch/plugin/user_role_with_shared_kibana_index_with_unique.yml

cc @pweil- @portante @richm 