### PR TITLE
bug 1463436. Allow defining cluster perms to allow export of ui objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ buildNumber.properties
 # Eclipse
 .project
 .classpath
+.checkstyle
 .settings/
 .metadata/
 

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/RolesSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/RolesSyncStrategy.java
@@ -22,6 +22,7 @@ package io.fabric8.elasticsearch.plugin.acl;
  */
 public interface RolesSyncStrategy {
     
+    static final String[] USER_ROLE_CLUSTER_ACTIONS = { "USER_CLUSTER_OPERATIONS" };
     static final String[] PROJECT_ROLE_ACTIONS = { "INDEX_PROJECT" };
     static final String[] KIBANA_ROLE_ALL_INDEX_ACTIONS = { "INDEX_ANY_KIBANA" };
     static final String[] KIBANA_ROLE_INDEX_ACTIONS = { "INDEX_KIBANA" };

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserRolesSyncStrategy.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/UserRolesSyncStrategy.java
@@ -49,6 +49,7 @@ public class UserRolesSyncStrategy extends BaseRolesSyncStrategy implements Role
                 //permissions for kibana Index
                 String kibIndexName = formatKibanaIndexName(cache, user, token, kibanaIndexMode);
                 RoleBuilder role = new RoleBuilder(roleName)
+                        .setClusters(USER_ROLE_CLUSTER_ACTIONS)
                         .setActions(kibIndexName, ALL, KIBANA_ROLE_INDEX_ACTIONS);
                 
                 //permissions for projects

--- a/src/test/resources/io/fabric8/elasticsearch/plugin/user_role_with_shared_kibana_index_with_unique.yml
+++ b/src/test/resources/io/fabric8/elasticsearch/plugin/user_role_with_shared_kibana_index_with_unique.yml
@@ -11,6 +11,7 @@ gen_project_operations:
     ?operations?:
       '*': [INDEX_OPERATIONS]
 gen_user_user2_bar_email_com:
+  cluster: [USER_CLUSTER_OPERATIONS]
   indices:
     .all_user2_bar_email_com:
       '*': [INDEX_PROJECT]


### PR DESCRIPTION
The PR:

* Allows specification of cluster permissions for non-ops users
* Enables fixing of exporting ui objects.

cc @portante