### PR TITLE
bug 1476062. Only seed documents when they are missing

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/PluginClient.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/PluginClient.java
@@ -16,19 +16,28 @@
 
 package io.fabric8.elasticsearch.plugin;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequestBuilder;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequestBuilder;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.action.get.GetRequestBuilder;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 
 import com.floragunn.searchguard.support.ConfigConstants;
+import com.google.common.collect.UnmodifiableIterator;
 
 /**
  * Facade to the ES client to simplify calls
@@ -43,6 +52,14 @@ public class PluginClient {
     public PluginClient(Client client) {
         this.client = client;
     }
+    
+    public IndexResponse createDocument(String index, String type, String id, String source) {
+        LOGGER.trace("create document: '{}/{}/{}' source: '{}'", index, type, id, source);
+        IndexRequestBuilder builder = client.prepareIndex(index, type, id).setSource(source);
+        addCommonHeaders(builder);
+        IndexResponse response = builder.get();
+        return response;
+    }
 
     public boolean indexExists(final String index) {
         LOGGER.trace("Checking for existance of index '{}'", index);
@@ -52,6 +69,40 @@ public class PluginClient {
         boolean exists = response.isExists();
         LOGGER.trace("Index '{}' exists? {}", index, exists);
         return exists;
+    }
+    
+    public boolean documentExists(final String index, final String type, final String id) {
+        LOGGER.trace("Checking for existence of document: '{}/{}/{}'", index, type, id);
+        GetRequestBuilder builder = client.prepareGet()
+            .setIndex(index)
+            .setType(type)
+            .setId(id)
+            .setFields(new String[] {});
+        addCommonHeaders(builder);
+        GetResponse response = builder.get();
+        final boolean exists = response.isExists();
+        LOGGER.trace("Document '{}/{}/{}' exists? {}", index, type, id, exists);
+        return exists;
+    }
+    
+    /**
+     * Retrieve the set of indices for a given alias
+     * 
+     * @param alias The alias to lookup
+     * @return The set of indices to the given alias
+     */
+    public Set<String> getIndicesForAlias(String alias){
+        LOGGER.trace("Retrieving indices for alias '{}'", alias);
+        GetAliasesRequestBuilder builder = this.client.admin().indices().prepareGetAliases(alias);
+        addCommonHeaders(builder);
+        GetAliasesResponse response = builder.get();
+        UnmodifiableIterator<String> keysIt = response.getAliases().keysIt();
+        Set<String> indices = new HashSet<>();
+        while (keysIt.hasNext()) {
+            indices.add(keysIt.next());
+        }
+        LOGGER.trace("Indices for alias '{}': {}", alias, indices);
+        return indices;
     }
 
     /**
@@ -64,6 +115,7 @@ public class PluginClient {
     public boolean alias(Map<String, String> aliases) {
         boolean acknowledged = false;
         if (aliases.isEmpty()) {
+            LOGGER.trace("The alias map is empty.  Nothing to do");
             return acknowledged;
         }
         IndicesAliasesRequestBuilder builder = this.client.admin().indices().prepareAliases();

--- a/src/main/java/io/fabric8/elasticsearch/util/IndexUtil.java
+++ b/src/main/java/io/fabric8/elasticsearch/util/IndexUtil.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A utility for manipulating index strings
+ *
+ */
+public class IndexUtil {
+    
+    /**
+     * Take a set of indices and remove the date suffix
+     * project.logging.ae5ca3cb-890e-11e7-b9c2-52540050d5ea.2017.09.06 becomes:
+     * project.logging.ae5ca3cb-890e-11e7-b9c2-52540050d5ea.*
+     * 
+     * @param value     the value to use in place of the date
+     * @param indices   the set of indices to process
+     * @return  A set of the indices with modified values
+     */
+    public Set<String> replaceDateSuffix(final String value, final Set<String> indices){
+        Set<String> modified = new HashSet<>();
+        final String sub = "." + value;
+        for (String index : indices) {
+            modified.add(index.replaceFirst("\\.\\d\\d\\d\\d\\.\\d\\d.\\d\\d$", sub));
+        }
+        return modified;
+    }
+
+}

--- a/src/test/java/io/fabric8/elasticsearch/util/IndexUtilTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/util/IndexUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class IndexUtilTest {
+
+    @Test
+    public void testReplaceDateSuffix() {
+        IndexUtil util = new IndexUtil();
+        Set<String> indices = new HashSet<>();
+        indices.add("project.logging.ae5ca3cb-890e-11e7-b9c2-52540050d5ea.2017.09.06");
+        indices.add("project.logging.ae5ca3cb-890e-11e7-b9c2-52540050d5ea.2017.09.09");
+        Set<String> replaced = util.replaceDateSuffix("*", indices);
+        assertEquals(1, replaced.size());
+        assertEquals("project.logging.ae5ca3cb-890e-11e7-b9c2-52540050d5ea.*", (String)replaced.toArray()[0]);
+    }
+
+}


### PR DESCRIPTION
This PR

* Modifies seeding code to only create index-patterns and alias when they do not already exist
* Requires an additional permission for the role to allow write to the kibana index