### PR TITLE
bug 1490719. Operations missing from .all alias

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -162,9 +162,8 @@ public class KibanaSeed implements ConfigurationSettings {
         if (context.isOperationsUser()) {
             // Check roles here, if user is a cluster-admin we should add
             LOGGER.debug("Adding indexes to alias '{}' for user '{}'", ADMIN_ALIAS_NAME, context.getUser());
-            buildAdminAlias(filteredProjects, projectPrefix);
-            filteredProjects.add(ADMIN_ALIAS_NAME);
             filteredProjects.add(OPERATIONS_PROJECT);
+            buildAdminAlias(filteredProjects, projectPrefix);
         } else {
             if (filteredProjects.isEmpty()) {
                 filteredProjects.add(BLANK_PROJECT);


### PR DESCRIPTION
This PR fixes the issue where .operations is missing from the .all alias

Test before fix:

```$ PUBLIC_MASTER_URL=https://192.168.122.89:8443 bundle exec cucumber --tags @test
#encoding: utf-8
Feature: The openshift-elasticsearch-plugin initializes access
  control to indices in the cluster and Kibana UI objects

  @kibana @test
  Scenario: The .all alias references all indices                 # features/openshift-elasticsearch-plugin.feature:27
    Given a user with the role of operations                      # features/step_definitions/policy_steps.rb:1
    And the .all alias initially does not exist                   # features/step_definitions/elasticsearch_steps.rb:7
    And logs were collected for the logging project               # features/step_definitions/elasticsearch_steps.rb:1
    When they log into Kibana                                     # features/step_definitions/kibana_steps.rb:1
    Then the .all alias should alias indices: operations, logging # features/step_definitions/elasticsearch_steps.rb:13
      Exp. the .all to include: ["logging", "operations"] but it only references ["logging"] (RuntimeError)
      ./features/step_definitions/elasticsearch_steps.rb:22:in `/^the (.*) alias should alias indices: (.*)$/'
      ./features/support/hooks.rb:14:in `block in <top (required)>'
      features/openshift-elasticsearch-plugin.feature:33:in `Then the .all alias should alias indices: operations, logging'

Failing Scenarios:
cucumber features/openshift-elasticsearch-plugin.feature:27 # Scenario: The .all alias references all indices

1 scenario (1 failed)
5 steps (1 failed, 4 passed)
0m9.944s

```
After:
```
Feature: The openshift-elasticsearch-plugin initializes access
  control to indices in the cluster and Kibana UI objects

  @kibana @test
  Scenario: The .all alias references all indices                 # features/openshift-elasticsearch-plugin.feature:27
    Given a user with the role of operations                      # features/step_definitions/policy_steps.rb:1
    And the .all alias initially does not exist                   # features/step_definitions/elasticsearch_steps.rb:7
    And logs were collected for the logging project               # features/step_definitions/elasticsearch_steps.rb:1
    When they log into Kibana                                     # features/step_definitions/kibana_steps.rb:1
    Then the .all alias should alias indices: operations, logging # features/step_definitions/elasticsearch_steps.rb:13

1 scenario (1 passed)
5 steps (5 passed)
0m13.045s
```