### PR TITLE
fix 1519705. All alias shows now indices

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -99,6 +99,9 @@ public class KibanaSeed implements ConfigurationSettings {
         LOGGER.debug("Found '{}' Index patterns for user", indexPatterns.size());
 
         Set<String> projects = new HashSet<>(context.getProjects());
+        if(context.isOperationsUser()) {
+            projects.add(OPERATIONS_PROJECT);
+        }
         List<String> filteredProjects = new ArrayList<String>(filterProjectsWithIndices(projectPrefix, projects));
         LOGGER.debug("projects for '{}' that have existing indexes: '{}'", context.getUser(), filteredProjects);
 
@@ -161,7 +164,6 @@ public class KibanaSeed implements ConfigurationSettings {
         if (context.isOperationsUser()) {
             // Check roles here, if user is a cluster-admin we should add
             LOGGER.debug("Adding indexes to alias '{}' for user '{}'", ADMIN_ALIAS_NAME, context.getUser());
-            filteredProjects.add(OPERATIONS_PROJECT);
             buildAdminAlias(filteredProjects, projectPrefix);
             filteredProjects.add(ADMIN_ALIAS_NAME);
         } else if (filteredProjects.isEmpty()) {


### PR DESCRIPTION
This PR fixes 1519705:

* Alias .operations if operations user and .operation indices exist

```
[2017-12-04 21:02:58,033][ERROR][io.fabric8.elasticsearch.plugin.kibana.KibanaSeed] Error executing Alias request
[.operations.*] IndexNotFoundException[no such index]

```