### PR TITLE
bug 1537857. Remove user header for requests without tokens and

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is an OpenShift plugin to ElasticSearch to:
 * Transform kibana index requests to support multitenant deployments for 
   non-operations users when so configured.
 
+
 *Note:*
 Previous versions of this plugin created a Kibana profile for each user regardless of their role,
 which is still the default mode of operation.  It is now possible to configure the Kibana index mode 

--- a/src/main/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchConfigurationException.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchConfigurationException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin;
+
+@SuppressWarnings("serial")
+public class OpenShiftElasticSearchConfigurationException extends RuntimeException {
+
+    public OpenShiftElasticSearchConfigurationException(String message) {
+        super(message);
+    }
+
+    public OpenShiftElasticSearchConfigurationException(String message, Throwable e) {
+        super(message, e);
+    }
+    
+}

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/DynamicACLFilter.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/DynamicACLFilter.java
@@ -109,10 +109,10 @@ public class DynamicACLFilter extends RestFilter implements ConfigurationSetting
                 // if create throws an exception, it means there was an issue with the token
                 // and username and the request failed authentication
                 final OpenshiftRequestContext requestContext = contextFactory.create(request, cache);
+                request = utils.modifyRequest(request, requestContext);
                 if (requestContext == OpenshiftRequestContext.EMPTY) {
                     return; // do not process in this plugin
                 }
-                request = utils.modifyRequest(request, requestContext);
                 request.putInContext(OPENSHIFT_REQUEST_CONTEXT, requestContext);
                 // grab the kibana version here out of "kbn-version" if we can
                 // -- otherwise use the config one

--- a/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardRolesMapping.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardRolesMapping.java
@@ -18,6 +18,7 @@ package io.fabric8.elasticsearch.plugin.acl;
 
 
 import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/src/main/java/io/fabric8/elasticsearch/plugin/auth/FileAuthenticationBackend.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/auth/FileAuthenticationBackend.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.auth;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.loader.YamlSettingsLoader;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+
+import com.floragunn.searchguard.action.configupdate.TransportConfigUpdateAction;
+import com.floragunn.searchguard.auth.AuthenticationBackend;
+import com.floragunn.searchguard.auth.HTTPAuthenticator;
+import com.floragunn.searchguard.user.AuthCredentials;
+import com.floragunn.searchguard.user.User;
+
+import io.fabric8.elasticsearch.plugin.OpenShiftElasticSearchConfigurationException;
+
+/**
+ * Provides 'basic' authorization using a file of usernames and passwords.
+ * The source is YAML based file of usernames and base64 encoded passwords:
+ * 
+ * ---
+ * # username of 'foo' with password 'bar'
+ * foo:
+ *   passwd: YmFyCg==
+ *   
+ * This authorization assumes the header is also base64 encoded and the password
+ * contains no colons (e.g. :).  This allows the username to be in an Openshift
+ * service account format (e.g. system:serviceaccount:logging:prometheus) and still
+ * be sent by the client with a parsable password.
+ * 
+ * The backend is configured as follows in the sg_config.yml:
+ * 
+ * searchguard:
+ *   authc:
+ *     my_domain:
+ *       enabled: true
+ *       order: 1
+ *       http_authenticator:
+ *         challange: false
+ *         type: io.fabric8.elasticsearch.plugin.auth.FileAuthenticationBackend
+ *         config:
+ *           file_path: /path/to/yamlfile
+ *       authentication_backend:
+ *         type: io.fabric8.elasticsearch.plugin.auth.FileAuthenticationBackend
+ *         config:
+ *           file_path: /path/to/yamlfile         
+ */
+public class FileAuthenticationBackend implements AuthenticationBackend, HTTPAuthenticator {
+
+    private static final String PASSWD = ".passwd";
+    protected static final String FILE = "file_path";
+    private final File auth; 
+    private Settings mappings;
+    private long lastModified;
+    
+    /*
+     * remove me if we need TransportConfigUpdateAction
+     */
+    public FileAuthenticationBackend(final Settings settings) {
+        this(settings, null);
+    }
+    
+    public FileAuthenticationBackend(final Settings settings, final TransportConfigUpdateAction tcua) {
+        String file = settings.get(FILE);
+        if(StringUtils.isBlank(file)) {
+            throw new OpenShiftElasticSearchConfigurationException("Unable to Configure FileAuthenticationBackend because file_path is empty");
+        }
+        auth = FileUtils.getFile(file);
+        if(!auth.exists()) {
+            throw new OpenShiftElasticSearchConfigurationException("Unable to Configure YmlFileAuthenticationBackend because file_path does not exist: " + file);
+        }
+        loadAuthFile();
+    }
+    
+    @Override
+    public AuthCredentials extractCredentials(RestRequest request) throws ElasticsearchSecurityException {
+        final String authorizationHeader = request.header("Authorization");
+        if (authorizationHeader != null) {
+            if (authorizationHeader.trim().toLowerCase().startsWith("basic ")) {
+                final String decoded = new String(DatatypeConverter.parseBase64Binary(authorizationHeader.split(" ")[1]),
+                        StandardCharsets.UTF_8);
+
+                //username:password
+                //Assume password is all chars from the last : to the end
+                //this is the only way to send service accounts
+               
+                final int delimiter = decoded.lastIndexOf(':');
+
+                String username = null;
+                String password = null;
+
+                if (delimiter > 0) {
+                    username = decoded.substring(0, delimiter);
+                    
+                    if(decoded.length() - 1 != delimiter) {
+                        password = decoded.substring(delimiter + 1).trim();
+                    }
+                }
+                if (username != null && StringUtils.isNotEmpty(password)) {
+                    return new AuthCredentials(username, password.getBytes(StandardCharsets.UTF_8)).markComplete();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean reRequestAuthentication(RestChannel channel, AuthCredentials credentials) {
+        // unsupported
+        return false;
+    }
+
+    @Override
+    public String getType() {
+        return FileAuthenticationBackend.class.getName();
+    }
+
+    @Override
+    public User authenticate(AuthCredentials credentials) throws ElasticsearchSecurityException {
+        if (credentials == null) {
+            throw new ElasticsearchSecurityException("Creditials are null while trying to authenticate");
+        }
+        Settings settings = loadAuthFile();
+        if(exists(settings, credentials.getUsername())){
+            final String hash = settings.get(credentials.getUsername() + PASSWD);
+            if(StringUtils.isNotBlank(hash)) {
+                final String saved = new String(DatatypeConverter.parseBase64Binary(hash), StandardCharsets.UTF_8).trim();
+                final String presented = new String(credentials.getPassword());
+                if(saved.equals(presented)) {
+                    return new User(credentials.getUsername());
+                }
+            }
+        }
+        throw new ElasticsearchSecurityException("Unable to authenticate {}", credentials.getUsername());
+    }
+
+    @Override
+    public boolean exists(User user) {
+        if(user == null || user.getName() == null) {
+            return false;
+        }
+        Settings settings = loadAuthFile();
+        return exists(settings, user.getName());
+    }
+    
+    private boolean exists(Settings settings, String username) {
+        return settings.names().contains(username);
+    }
+
+    private Settings loadAuthFile() {
+        long now = auth.lastModified();
+        if (now > lastModified) {
+            try {
+                BytesReference ref = new BytesArray(FileUtils.readFileToByteArray(auth));
+                mappings = Settings.builder().put(new YamlSettingsLoader().load(ref.toBytes())).build();
+                lastModified = now;
+            } catch (final Exception e) {
+                throw new OpenShiftElasticSearchConfigurationException("Unable to parse " + auth.getAbsolutePath(), e);
+            }
+        }
+        return mappings;
+    }
+
+}

--- a/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
+++ b/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
@@ -32,7 +32,6 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 
-import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 

--- a/src/test/java/io/fabric8/elasticsearch/plugin/Samples.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/Samples.java
@@ -28,6 +28,7 @@ public enum Samples {
     OPENSHIFT_ROLES_ACL("searchguard_roles_acl_with_openshift_projects.yml"), 
     OPENSHIFT_ROLESMAPPING_ACL("searchguard_rolesmapping_acl_with_openshift_projects.yml"),
     ROLES_OPS_SHARED_KIBANA_INDEX("roles_ops_shared_kibana_index.yml"),
+    PASSWORDS("passwords.yml"),
     ROLES_SHARED_KIBANA_INDEX("roles_shared_kibana_index.yml"),
     ROLES_SHARED_OPS_KIBANA_INDEX("roles_shared_ops_kibana_index.yml"),
     ROLES_SHARED_NON_OPS_KIBANA_INDEX("roles_shared_non_ops_kibana_index.yml"),

--- a/src/test/java/io/fabric8/elasticsearch/plugin/auth/FileAuthenticationBackendTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/auth/FileAuthenticationBackendTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.elasticsearch.plugin.auth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+import org.apache.commons.io.FileUtils;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.floragunn.searchguard.action.configupdate.TransportConfigUpdateAction;
+import com.floragunn.searchguard.user.AuthCredentials;
+import com.floragunn.searchguard.user.User;
+
+import io.fabric8.elasticsearch.plugin.OpenShiftElasticSearchConfigurationException;
+import io.fabric8.elasticsearch.plugin.Samples;
+
+public class FileAuthenticationBackendTest {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private FileAuthenticationBackend auth;
+    private User user;
+    private Settings settings;
+    private File tmp;
+    private TransportConfigUpdateAction tcua = mock(TransportConfigUpdateAction.class);
+    
+    @Before
+    public void setup() throws IOException {
+        tmp = File.createTempFile("passwd", Integer.toString(new Random().nextInt()), new File(System.getProperty("java.io.tmpdir")));
+        FileUtils.writeStringToFile(tmp, Samples.PASSWORDS.getContent());
+        givenFilePath(tmp.getAbsolutePath());
+        givenAuthenticationBackend();
+    }
+    
+    private void givenFilePath(String path) {
+        settings = Settings.builder().put(FileAuthenticationBackend.FILE, path).build();
+    }
+    
+    private void givenAuthenticationBackend() {
+        auth = new FileAuthenticationBackend(settings, tcua);
+    }
+    
+    private User whenAuthenticating(String username, String passwd) {
+        AuthCredentials credentials = new AuthCredentials(username, passwd.getBytes());
+        return auth.authenticate(credentials );
+    }
+    
+    @Test(expected = OpenShiftElasticSearchConfigurationException.class)
+    public void testInitializationWithEmptyFilePath() {
+        givenFilePath("");
+        givenAuthenticationBackend();
+    }
+    
+    public void testReRequestAuthenticationAlwaysReturnsFalse() {
+        assertFalse(auth.reRequestAuthentication(null, null));
+    }
+    
+    @Test
+    public void testExtractCredentialsWithNoAuthHeader() {
+        RestRequest request = mock(RestRequest.class);
+        when(request.header(eq(AUTHORIZATION))).thenReturn(null);
+        assertNull(auth.extractCredentials(request));
+    }
+
+    @Test
+    public void testExtractCredentialsWithAuthHeaderNotBasic() {
+        RestRequest request = mock(RestRequest.class);
+        when(request.header(eq(AUTHORIZATION))).thenReturn("foo bar");
+        assertNull(auth.extractCredentials(request));
+    }
+    
+    @Test
+    public void testExtractCredentialsWithAuthHeaderNoPassword() {
+        RestRequest request = mock(RestRequest.class);
+        when(request.header(eq(AUTHORIZATION))).thenReturn("basic Zm9vOgo="); //basic foo:
+        assertNull("Exp a password to be required to auth", auth.extractCredentials(request));
+    }
+    
+    @Test
+    public void testExtractCredentialsWithAuthHeaderAndPassword() {
+        RestRequest request = mock(RestRequest.class);
+        when(request.header(eq(AUTHORIZATION))).thenReturn("Basic Zm9vOmJhcgo="); //Basic foo:bar
+        AuthCredentials exp = new AuthCredentials("foo","bar".getBytes());
+        AuthCredentials act = auth.extractCredentials(request);
+        assertEquals("Exp. the AuthCredentials to match", exp, act);
+    }
+    
+    @Test(expected = OpenShiftElasticSearchConfigurationException.class)
+    public void testInitializationWithNonExistentFilePath() {
+        givenFilePath("/foo/bar");
+        givenAuthenticationBackend();
+    }
+
+    @Test(expected = OpenShiftElasticSearchConfigurationException.class)
+    public void testInitializationWithUnParsableContent() throws Exception {
+        FileUtils.writeStringToFile(tmp, "random content");
+        //givenFilePath
+        givenAuthenticationBackend();
+    }
+
+    @Test(expected = ElasticsearchSecurityException.class)
+    public void testAuthenticateWhenUsernameNotFound() {
+        //givenFilePath
+        //givenAuthenticationBackend
+        whenAuthenticating("somerandomuser", "somepasswd");
+    }
+
+    @Test(expected = ElasticsearchSecurityException.class)
+    public void testAuthenticateWhenUsernameIsFoundAndPasswordMatchFails() {
+        //givenFilePath
+        //givenAuthenticationBackend
+        whenAuthenticating("foo", "somepasswd");
+    }
+
+    @Test
+    public void testAuthenticateWhenUsernameIsFoundAndPasswordMatchSucceeds() {
+        //givenFilePath
+        //givenAuthenticationBackend
+        user = whenAuthenticating("foo", "bar");
+        assertEquals("foo", user.getName());
+    }
+
+    @Test
+    public void testExistsWhenUserExists() {
+        //givenFilePath
+        //givenAuthenticationBackend
+        user = new User("foo");
+        assertTrue("Exp. true when user does exist in the file", auth.exists(user));
+    }
+
+    @Test
+    public void testExistsWhenUserDoesNotExists() {
+        user = new User("someuser");
+        assertFalse("Exp. false when user does not exist in the file", auth.exists(user));
+    }
+
+}

--- a/src/test/resources/io/fabric8/elasticsearch/plugin/passwords.yml
+++ b/src/test/resources/io/fabric8/elasticsearch/plugin/passwords.yml
@@ -14,17 +14,6 @@
 # limitations under the License.
 #
 
-openshift:
-  acl:
-    users:
-      names: ["system.test.user", "system.logging.test"]
-      system.test.user:
-        execute: ["actionrequestfilter.test"]
-        actionrequestfilter.test.comment: "user can only write"
-      system.logging.test:
-        bypass: ["*"]
-        execute: ["actionrequestfilter.logging"]
-        actionrequestfilter.logging.comment: "logging can only read from every other index"
-      system.logging.test.*.comment: "test can do anything in the test index"
-      system.logging.test.*.indices: [".test.*"]
-      
+# username with a b64 encoded password of 'bar'
+foo:
+  passwd: YmFyCg==


### PR DESCRIPTION
fixup support for retrieving metrics

This PR:
* Adds support for a custom 'Basic' authentication to handle openshift service accounts from file
* removes user header from requests where no bearer token is provided
* no longer returns early if no bearer token exists. depends on additional SG processing