### PR TITLE
fix #104. Skip Kibana seeding if no default Kibana index exists

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -83,7 +83,10 @@ public class KibanaSeed implements ConfigurationSettings {
     }
 
     public void setDashboards(final OpenshiftRequestContext context, Client client, String kibanaVersion, final String projectPrefix) {
-
+        if(!pluginClient.indexExists(defaultKibanaIndex)) {
+            LOGGER.debug("Default Kibana index '{}' does not exist. Skipping Kibana seeding", defaultKibanaIndex);
+            return;
+        }
         LOGGER.debug("Begin setDashboards:  projectPrefix '{}' for user '{}' projects '{}' kibanaIndex '{}'",
                 projectPrefix, context.getUser(), context.getProjects(), context.getKibanaIndex());
 


### PR DESCRIPTION
This PR:
* fixes #104 by skipping seeding if the default Kibana does not exist