### PR TITLE
Revert revert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
+++ b/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
@@ -79,12 +79,12 @@ public class RequestUtils implements ConfigurationSettings  {
     
     public String getBearerToken(RestRequest request) {
         String token = "";
-        if (request.getHeaders().keySet().contains(AUTHORIZATION_HEADER)) {
+        if (request.header(AUTHORIZATION_HEADER) != null) {
             final String[] auth = StringUtils.defaultIfEmpty(request.header(AUTHORIZATION_HEADER), "").split(" ");
             if (auth.length >= 2 && "Bearer".equals(auth[0])) {
                 token = auth[1];
             }
-        } else if (request.getHeaders().keySet().contains(X_FORWARDED_ACCESS_TOKEN)) {
+        } else if (request.header(X_FORWARDED_ACCESS_TOKEN) != null) {
             token = StringUtils.defaultIfEmpty(request.header(X_FORWARDED_ACCESS_TOKEN), "");
         }
         return token;

--- a/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
+++ b/src/main/java/io/fabric8/elasticsearch/util/RequestUtils.java
@@ -57,6 +57,7 @@ public class RequestUtils implements ConfigurationSettings  {
     
     private static final Logger LOGGER = Loggers.getLogger(RequestUtils.class);
     public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String X_FORWARDED_ACCESS_TOKEN = "x-forwarded-access-token";
 
     private final String proxyUserHeader;
     private final OpenshiftClientFactory k8ClientFactory;
@@ -77,11 +78,16 @@ public class RequestUtils implements ConfigurationSettings  {
     }
     
     public String getBearerToken(RestRequest request) {
-        final String[] auth = StringUtils.defaultIfEmpty(request.header(AUTHORIZATION_HEADER), "").split(" ");
-        if (auth.length >= 2 && "Bearer".equals(auth[0])) {
-            return auth[1];
+        String token = "";
+        if (request.getHeaders().keySet().contains(AUTHORIZATION_HEADER)) {
+            final String[] auth = StringUtils.defaultIfEmpty(request.header(AUTHORIZATION_HEADER), "").split(" ");
+            if (auth.length >= 2 && "Bearer".equals(auth[0])) {
+                token = auth[1];
+            }
+        } else if (request.getHeaders().keySet().contains(X_FORWARDED_ACCESS_TOKEN)) {
+            token = StringUtils.defaultIfEmpty(request.header(X_FORWARDED_ACCESS_TOKEN), "");
         }
-        return "";
+        return token;
     }
     
     public boolean isClientCertAuth(final ThreadContext threadContext) {

--- a/src/test/java/io/fabric8/elasticsearch/plugin/OpenshiftRequestContextFactoryTest.java
+++ b/src/test/java/io/fabric8/elasticsearch/plugin/OpenshiftRequestContextFactoryTest.java
@@ -26,18 +26,20 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestRequest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-import io.fabric8.elasticsearch.plugin.ConfigurationSettings;
-import io.fabric8.elasticsearch.plugin.OpenshiftRequestContextFactory;
 import io.fabric8.elasticsearch.plugin.OpenshiftRequestContextFactory.OpenshiftRequestContext;
 import io.fabric8.elasticsearch.util.RequestUtils;
 import io.fabric8.elasticsearch.util.TestRestRequest;
@@ -51,7 +53,13 @@ import io.fabric8.openshift.api.model.ProjectList;
 import io.fabric8.openshift.api.model.ProjectListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+@RunWith(value = Parameterized.class)
 public class OpenshiftRequestContextFactoryTest {
+
+    @Parameter(value = 0)
+    public String authHeader;
+    @Parameter(value = 1)
+    public String authToken;
 
     private Settings.Builder settingsBuilder = Settings.builder();
     private OpenshiftRequestContextFactory factory;
@@ -64,8 +72,16 @@ public class OpenshiftRequestContextFactoryTest {
     public void setUp() throws Exception {
         Map<String, List<String>> headers = new HashMap<String, List<String>>();
         headers.put(ConfigurationSettings.DEFAULT_AUTH_PROXY_HEADER, Arrays.asList("fooUser"));
-        headers.put("Authorization", Arrays.asList("Bearer ABC123"));
+        headers.put(authHeader, Arrays.asList(authToken));
         request = new TestRestRequest(headers);
+    }
+
+    @Parameters()
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+          {"Authorization", "Bearer ABC123"},
+          {"x-forwarded-access-token", "ABC123"}
+        });
     }
 
     private void givenUserContextFactory(boolean isOperationsUser) {
@@ -125,7 +141,7 @@ public class OpenshiftRequestContextFactoryTest {
 
     @Test
     public void testCreatingUserContextWhenUserHasBackSlash() throws Exception {
-        Map<String, List<String>> headers = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, List<String>> headers = new HashMap<>();
         headers.put(ConfigurationSettings.DEFAULT_AUTH_PROXY_HEADER, Arrays.asList("test\\user"));
         headers.put("Authorization", Arrays.asList("Bearer ABC123"));
         request = new TestRestRequest(headers);


### PR DESCRIPTION
@josefkarasek getHeaders() and headers(key) dont consistenly return the same info.  This PR adds your changes back in and fixes a failure where not using the new proxy causes authorization failure.