### PR TITLE
bug 1694884. Don't explicitly define kibana index replica

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/kibana/KibanaSeed.java
@@ -197,7 +197,6 @@ public class KibanaSeed implements ConfigurationSettings {
                 LOGGER.debug("Copying '{}' to '{}'", defaultKibanaIndex, userIndex);
                 Settings settings = Settings.builder()
                         .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 0)
                         .build();
                 pluginClient.copyIndex(defaultKibanaIndex, userIndex, settings, CONFIG_DOC_TYPE);
                 return true;


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667801 by removing the explicit replica setting when creating the index and let it rely on the template