### PR TITLE
declare OPENSHIFT_ACL_EXPIRE_IN_MILLIS in OpenShiftElasticSearchPlugin

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchPlugin.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/OpenShiftElasticSearchPlugin.java
@@ -214,9 +214,10 @@ public class OpenShiftElasticSearchPlugin extends Plugin implements Configuratio
         settings.add(Setting.boolSetting("openshift.operations.allow_cluster_reader", false, Property.NodeScope));
         settings.add(Setting.simpleString("openshift.kibana.index.mode", Property.NodeScope));
         settings.add(Setting.simpleString(OPENSHIFT_ACL_ROLE_STRATEGY, Property.NodeScope));
-        settings.add(Setting.listSetting(OPENSHIFT_KIBANA_OPS_INDEX_PATTERNS, Arrays.asList(DEFAULT_KIBANA_OPS_INDEX_PATTERNS), 
+        settings.add(Setting.listSetting(OPENSHIFT_KIBANA_OPS_INDEX_PATTERNS, Arrays.asList(DEFAULT_KIBANA_OPS_INDEX_PATTERNS),
                 Function.identity(), Property.NodeScope, Property.Dynamic));
-            
+        settings.add(Setting.simpleString(OPENSHIFT_ACL_EXPIRE_IN_MILLIS, Property.NodeScope));
+
         return settings;
     }
 


### PR DESCRIPTION
if we use the openshift.acl.expire_in_millis in elasticsearch.yml, we will get some error log. Elasticsearch can not start .

```
[2019-04-22T02:49:16,878][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [logging-es-data-master-dgogq2rs] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalArgumentException: unknown setting [openshift.acl.expire_in_millis] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
```