### PR TITLE
Bug 1731833: bump guava to 25.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>25.1-jre</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This issue bumps guava to 25.1-jre to resolve:
* https://bugzilla.redhat.com/show_bug.cgi?id=1745011
* https://bugzilla.redhat.com/show_bug.cgi?id=1731833
* https://bugzilla.redhat.com/show_bug.cgi?id=1731834