### PR TITLE
fix missing token for OpenShiftAPIService requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.fabric8.elasticsearch</groupId>
     <artifactId>openshift-elasticsearch-plugin</artifactId>
-    <version>5.6.13.10</version>
+    <version>5.6.13.11-SNAPSHOT</version>
     <name>Openshift Elasticsearch Plugin</name>
 
     <url>http://fabric8.io/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.fabric8.elasticsearch</groupId>
     <artifactId>openshift-elasticsearch-plugin</artifactId>
-    <version>5.6.13.10-SNAPSHOT</version>
+    <version>5.6.13.10</version>
     <name>Openshift Elasticsearch Plugin</name>
 
     <url>http://fabric8.io/</url>

--- a/src/main/java/io/fabric8/elasticsearch/plugin/OpenshiftAPIService.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/OpenshiftAPIService.java
@@ -65,6 +65,7 @@ public class OpenshiftAPIService {
         try (DefaultOpenShiftClient client = factory.buildClient(token)) {
             Request okRequest = new Request.Builder()
                     .url(client.getMasterUrl() + "apis/user.openshift.io/v1/users/~")
+                    .header("Authorization", "Bearer " + token)
                     .header(ACCEPT, APPLICATION_JSON)
                     .build();
             response = client.getHttpClient().newCall(okRequest).execute();
@@ -86,6 +87,7 @@ public class OpenshiftAPIService {
         try (DefaultOpenShiftClient client = factory.buildClient(token)) {
             Request request = new Request.Builder()
                 .url(client.getMasterUrl() + "apis/project.openshift.io/v1/projects")
+                .header("Authorization", "Bearer " + token)
                 .header(ACCEPT, APPLICATION_JSON)
                 .build();
             Response response = client.getHttpClient().newCall(request).execute();
@@ -142,6 +144,7 @@ public class OpenshiftAPIService {
             payload.endObject();
             Request request = new Request.Builder()
                     .url(String.format("%sapis/authorization.openshift.io/v1/subjectaccessreviews", client.getMasterUrl(), project))
+                    .header("Authorization", "Bearer " + token)
                     .header(CONTENT_TYPE, APPLICATION_JSON)
                     .header(ACCEPT, APPLICATION_JSON)
                     .post(RequestBody.create(MediaType.parse(APPLICATION_JSON), payload.string()))

--- a/src/main/java/io/fabric8/elasticsearch/plugin/OpenshiftRequestContextFactory.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/OpenshiftRequestContextFactory.java
@@ -141,7 +141,7 @@ public class OpenshiftRequestContextFactory
         if (StringUtils.isNotBlank(token)){
             try {
                 return contextCache.get(token);
-            } catch(ExecutionException e) {
+            } catch(Exception e) {
                 LOGGER.error("Error trying to fetch user's context from the cache",e);
             }
         }


### PR DESCRIPTION
This PR explicitly sets a user's token on the request as a header when making calls to the Openshift API server to resolve an issue where there was unexpected response when executing a SAR