### PR TITLE
Bug 1746377: Fetch indices instead of search to seed index patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.fabric8.elasticsearch</groupId>
     <artifactId>openshift-elasticsearch-plugin</artifactId>
-    <version>5.6.16.1-SNAPSHOT</version>
+    <version>5.6.16.1</version>
     <name>Openshift Elasticsearch Plugin</name>
 
     <url>http://fabric8.io/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.fabric8.elasticsearch</groupId>
     <artifactId>openshift-elasticsearch-plugin</artifactId>
-    <version>5.6.16.1</version>
+    <version>5.6.16.2-SNAPSHOT</version>
     <name>Openshift Elasticsearch Plugin</name>
 
     <url>http://fabric8.io/</url>

--- a/src/it/java/io/fabric8/elasticsearch/ElasticsearchIntegrationTest.java
+++ b/src/it/java/io/fabric8/elasticsearch/ElasticsearchIntegrationTest.java
@@ -523,6 +523,13 @@ public abstract class ElasticsearchIntegrationTest {
         assertEquals(String.format("Exp. %s to be forbidden for %s", username, uri), 403, response.code());
     }
 
+    protected void assertThatResponseIsNotFound() {
+        String username = (String) testContext.get(USERNAME);
+        Response response = (Response) testContext.get(RESPONSE);
+        String uri = (String) testContext.get(URI);
+        assertEquals(String.format("Exp. %s to be not found for %s", username, uri), 404, response.code());
+    }
+    
     protected void assertThatResponseIsUnauthorized() {
         String username = (String) testContext.get(USERNAME);
         Response response = (Response) testContext.get(RESPONSE);

--- a/src/it/java/io/fabric8/elasticsearch/KibanaIndexModeIntegrationBase.java
+++ b/src/it/java/io/fabric8/elasticsearch/KibanaIndexModeIntegrationBase.java
@@ -41,7 +41,10 @@ public abstract class KibanaIndexModeIntegrationBase extends ElasticsearchIntegr
     
     @Before
     public void setup() throws Exception {
-        givenDocumentIsIndexed("project.multi-tenancy-1.uuid.1970.01.01", "test", "0", "multi-tenancy-1-doc0");
+        //https://bugzilla.redhat.com/show_bug.cgi?id=1746377
+        for (int i = 0; i < 1100; ++ i) {
+            givenDocumentIsIndexed("project.multi-tenancy-1.uuid.1970.01.01", "test", String.valueOf(i), "multi-tenancy-1-doc0");
+        }
         givenDocumentIsIndexed("project.multi-tenancy-2.uuid.1970.01.01", "test", "0", "multi-tenancy-2-doc0");
         givenDocumentIsIndexed("project.multi-tenancy-3.uuid.1970.01.01", "test", "0", "multi-tenancy-3-doc0");
     }

--- a/src/it/java/io/fabric8/elasticsearch/KibanaIndexModeSharedOpsIntegrationTest.java
+++ b/src/it/java/io/fabric8/elasticsearch/KibanaIndexModeSharedOpsIntegrationTest.java
@@ -45,6 +45,17 @@ public class KibanaIndexModeSharedOpsIntegrationTest extends KibanaIndexModeInte
         //verify access to unique kibana index
         whenGettingDocument(String.format("%s/config/%s", kibanaIndex, OLD_KIBANA_VERSION));
         assertThatResponseIsSuccessful();
+
+        
+        //verify seeded index patterns
+        for (String project : projects) {
+            whenGettingDocument(String.format("%s/index-pattern/%s", kibanaIndex, formatProjectIndexPattern(project, "uuid")));
+            assertThatResponseIsSuccessful();
+        }
+
+        //verify access to index pattern for project we dont administer
+        whenGettingDocument(String.format("%s/index-pattern/%s", kibanaIndex, formatProjectIndexPattern("multi-tenancy-3", "uuid")));
+        assertThatResponseIsNotFound();
         
         //verify search to individual projects
         for (String project : projects) {

--- a/src/main/java/io/fabric8/elasticsearch/plugin/PluginClient.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/PluginClient.java
@@ -57,6 +57,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.sort.SortOrder;
 
 import com.floragunn.searchguard.support.ConfigConstants;
 
@@ -163,6 +164,7 @@ public class PluginClient {
                         .setTypes(types)
                         .setSize(size)
                         .setFetchSource(fetchSource)
+                        .addSort("_index", SortOrder.ASC)
                         .get();
             }
 


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746377 by:

* retrieving and comparing against a list of indices instead of using a search result