### PR TITLE
Disable HTTP2 in communication with OpenShift

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/OpenshiftAPIService.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/OpenshiftAPIService.java
@@ -194,6 +194,7 @@ public class OpenshiftAPIService {
     interface OpenShiftClientFactory {
         default DefaultOpenShiftClient buildClient(final String token) {
             Config config = new ConfigBuilder().withOauthToken(token).build();
+            config.setHttp2Disable(true);
             return new DefaultOpenShiftClient(config);
         }
         


### PR DESCRIPTION
Disables HTTP/2 protocol when communicating with OpenShift API Server
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1835396