### PR TITLE
Bug 1835396: Disable http/2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.fabric8.elasticsearch</groupId>
     <artifactId>openshift-elasticsearch-plugin</artifactId>
-    <version>5.6.16.3</version>
+    <version>5.6.16.4-SNAPSHOT</version>
     <name>Openshift Elasticsearch Plugin</name>
 
     <url>http://fabric8.io/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.fabric8.elasticsearch</groupId>
     <artifactId>openshift-elasticsearch-plugin</artifactId>
-    <version>5.6.16.3-SNAPSHOT</version>
+    <version>5.6.16.3</version>
     <name>Openshift Elasticsearch Plugin</name>
 
     <url>http://fabric8.io/</url>


### PR DESCRIPTION
This PR disables http/2 to resolve issues running an alternate nodes from typical RH

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1835396